### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/build-nodebb.yml
+++ b/.github/workflows/build-nodebb.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build and publish on Github (beta)
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           RELEASE: ${{ steps.NodeBB-beta.outputs.release }}
         with:
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build and publish on Github (stable)
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         env:
           RELEASE: ${{ steps.NodeBB-stable.outputs.release }}
         with:


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore